### PR TITLE
fix (Haskell): replace removed foldWithKey with foldrWithKey

### DIFF
--- a/Haskell/ElixirFM/Elixir/Resolve.hs
+++ b/Haskell/ElixirFM/Elixir/Resolve.hs
@@ -348,7 +348,7 @@ instance Resolve String where
                                 let x = (expand . domain) e,
                                 let l = Lexeme r e,
 
-                                z <- (Map.foldWithKey (\ k x y -> (k, [foldl (flip ((:) . wrap)) [] x]) : y) []
+                                z <- (Map.foldrWithKey (\ k x y -> (k, [foldl (flip ((:) . wrap)) [] x]) : y) []
 
                                   -- (Map.foldWithKey (\ k x y -> (k, [wrap (Tokens (reverse x))]) : y) []
 
@@ -618,7 +618,7 @@ instance Resolve [UPoint] where
                                 let x = (expand . domain) e,
                                 let l = Lexeme r e,
 
-                                z <- (Map.foldWithKey (\ k x y -> (k, [foldl (flip ((:) . wrap)) [] x]) : y) []
+                                z <- (Map.foldrWithKey (\ k x y -> (k, [foldl (flip ((:) . wrap)) [] x]) : y) []
 
                                   -- (Map.foldWithKey (\ k x y -> (k, [wrap (Tokens (reverse x))]) : y) []
 


### PR DESCRIPTION
Build was successful (`Haskell 8`). According to the [docs](https://hackage.haskell.org/package/containers-0.4.0.0/docs/Data-Map.html) this should be the correct way to fix this. 

Should fix #11 